### PR TITLE
move dependency injection into a separate file - removes circular dependency.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,4 @@
 var crypto = require('crypto');
 
-exports.__browserify = function (crypto, exports) {
-  exports = exports || {};
-  var ciphers = require('./encrypter')(crypto);
-  exports.createCipher = ciphers.createCipher;
-  exports.createCipheriv = ciphers.createCipheriv;
-  var deciphers = require('./decrypter')(crypto);
-  exports.createDecipher = deciphers.createDecipher;
-  exports.createDecipheriv = deciphers.createDecipheriv;
-  var modes = require('./modes');
-  function listCiphers () {
-    return Object.keys(modes);
-  }
-  exports.listCiphers = listCiphers;
-};
+exports.__browserify = require('./inject')
 exports.__browserify(crypto, module.exports);

--- a/inject.js
+++ b/inject.js
@@ -1,0 +1,15 @@
+module.exports = function (crypto, exports) {
+  exports = exports || {};
+  var ciphers = require('./encrypter')(crypto);
+  exports.createCipher = ciphers.createCipher;
+  exports.createCipheriv = ciphers.createCipheriv;
+  var deciphers = require('./decrypter')(crypto);
+  exports.createDecipher = deciphers.createDecipher;
+  exports.createDecipheriv = deciphers.createDecipheriv;
+  var modes = require('./modes');
+  function listCiphers () {
+    return Object.keys(modes);
+  }
+  exports.listCiphers = listCiphers;
+};
+


### PR DESCRIPTION
This makes it tidier so that we don't `require('crypto')` while we are currently creating `crypto`.
Once you merge this I'll merge https://github.com/dominictarr/crypto-browserify/pull/59/files but just point it at
`require('browserify-aes/inject')` instead of `require('browserify-aes').__browserify` 
