### PR TITLE
Consistency with node crypto api for setAutoPadding

### DIFF
--- a/decrypter.js
+++ b/decrypter.js
@@ -41,6 +41,7 @@ Decipher.prototype._final = function () {
 }
 Decipher.prototype.setAutoPadding = function (setTo) {
   this._autopadding = !!setTo
+  return this
 }
 function Splitter () {
   if (!(this instanceof Splitter)) {

--- a/encrypter.js
+++ b/encrypter.js
@@ -42,6 +42,7 @@ Cipher.prototype._final = function () {
 }
 Cipher.prototype.setAutoPadding = function (setTo) {
   this._autopadding = !!setTo
+  return this
 }
 
 function Splitter () {


### PR DESCRIPTION
In node, the Cipher class allows chaining the `setAutoPadding` method. So the following will work in node, but fail when browserified:

```
var cipher = crypto
  .createCipheriv('aes-256-cbc', key, iv)
  .setAutoPadding(false)
cipher.update(data)
```

Returning `this` from `setAutoPadding` fixes the issue.