### PR TITLE
Clean up bufferToArray()

### DIFF
--- a/aes.js
+++ b/aes.js
@@ -81,9 +81,7 @@ AES.keySize = 256 / 8
 AES.prototype.keySize = AES.keySize
 
 function bufferToArray (buf) {
-  if (!Buffer.isBuffer(buf)) {
-    throw new TypeError('Input must be a Buffer')
-  }
+  // Convert unexpected float to int32
   var len = (buf.length / 4) | 0
   var out = new Array(len)
   for (var i = 0; i < len; i++) {

--- a/aes.js
+++ b/aes.js
@@ -81,14 +81,17 @@ AES.keySize = 256 / 8
 AES.prototype.keySize = AES.keySize
 
 function bufferToArray (buf) {
-  var len = buf.length / 4
+  if (!Buffer.isBuffer(buf)) {
+    throw new TypeError('Input must be a Buffer')
+  }
+  var len = (buf.length / 4) | 0
   var out = new Array(len)
-  var i = -1
-  while (++i < len) {
+  for (var i = 0; i < len; i++) {
     out[i] = buf.readUInt32BE(i * 4)
   }
   return out
 }
+
 function AES (key) {
   this._key = bufferToArray(key)
   this._doReset()


### PR DESCRIPTION
- `readUInt32BE(i * 4)` throw out of range error if `Buffer.length` isn't multiples of 4
- `buf.length / 4` Is a `float` number, it has been converted to `int` by `(buf.length / 4) | 0`
- Use for loop instead of while loop