### PR TITLE
Handle invalid padding values

### DIFF
--- a/decrypter.js
+++ b/decrypter.js
@@ -79,6 +79,9 @@ Splitter.prototype.flush = function () {
 
 function unpad (last) {
   var padded = last[15]
+  if (padded < 1 || padded > 16) {
+    throw new Error('invalid padding')
+  }
   var i = -1
   while (++i < padded) {
     if (last[(i + (16 - padded))] !== padded) {

--- a/test/index.js
+++ b/test/index.js
@@ -591,11 +591,14 @@ fifteens2[1] = 6
 var two = _crypto.randomBytes(16)
 two[15] = 2
 two[14] = 1
+var zeroes = Buffer.alloc(16)
+var seventeens = Buffer.alloc(16, 17)
+var ff = Buffer.alloc(16, 0xff)
 
 corectPaddingWords(sixteens, Buffer.alloc(0))
 corectPaddingWords(fifteens, Buffer.from([5]))
 corectPaddingWords(one, one.slice(0, -1))
-;[sixteens2, fifteens2, two].forEach((x) => {
+;[sixteens2, fifteens2, two, zeroes, seventeens, ff].forEach((x) => {
   incorectPaddingthrows(x)
   incorectPaddingDoesNotThrow(x)
 })


### PR DESCRIPTION
When deciphering with aes128, padding values that are zero or above 16 would throw an error when using node's crypto library. This was not the behaviour in browserify-aes. This change should resolve that.